### PR TITLE
[BT-132] HMR port

### DIFF
--- a/src/compileJs.js
+++ b/src/compileJs.js
@@ -13,6 +13,7 @@ module.exports = customConfig => {
     src: './src/index.js',
     dst: './dist/js',
     watch: false,
+    hmrPort: 3123,
   }, customConfig);
 
   if (!config.src) {
@@ -46,7 +47,9 @@ module.exports = customConfig => {
   // Build bundle with browserify configuration.
   let bundler = browserify(config.src, browserifyConfig);
   if (config.watch) {
-    bundler.plugin(browserifyHmr);
+    bundler.plugin(browserifyHmr, {
+      port: config.hmrPort,
+    });
     bundler = watchify(bundler);
   }
   bundler.transform(babelify);

--- a/src/compileJs.spec.js
+++ b/src/compileJs.spec.js
@@ -21,6 +21,7 @@ describe('compileJs method', () => {
         src: './src/index.js',
         dst: './dist/js',
         watch: false,
+        hmrPort: 3123,
       });
     });
 


### PR DESCRIPTION
Note: This is PR to master.

This PR allows to supply port to HMR, which should solve the problem of running two and more repos simultaneously.

The idea is that when this is released, repos that consume it explicitly specify the HMR port and nothing conflicts anymore.

I also tried a different approach - first check if port is taken, then increment the port number until free one is found. I abandoned the idea, because the port checking is asynchronous and because of that half of compileJs.js code had to be moved into callback, which seemed like a major drawback.
