### PR TITLE
[BT-132] HMR port fix 2 (client side)

### DIFF
--- a/src/compileJs.js
+++ b/src/compileJs.js
@@ -51,7 +51,7 @@ module.exports = customConfig => {
       // Start HMR on this port
       port: config.hmrPort,
       // Tell client side the url of HMR server
-      url: 'http://localhost:' + config.hmrPort,
+      url: `http://localhost:${config.hmrPort}`,
     });
     bundler = watchify(bundler);
   }


### PR DESCRIPTION
I did not test the client side last time, just the fact that 2 HMR servers are started without any propblems, that is how it slipped through.

Explanation from the browserify-hmr's README is a bit vague https://www.npmjs.com/package/browserify-hmr:
- `port` is a number that sets the port to listen on if "websocket" mode is used. If you change this, you'll most likely want to change the url setting too. Defaults to 3123.
- `url` is a string which sets the update URL that the websocket connection or Browserify bundle is accessible at. In "websocket" mode, this defaults to "http://localhost:3123". This is required for the "ajax" mode. This is not required for "fs" mode.

Basically, the port for backend was working fine, I expected client side to automagically pick up the same port. Later it became clear that client side needs to be explicitly set to url, which should contain the new port in it, or else it uses the hardcoded url with default port.
